### PR TITLE
Use hyperhtml in sample presentation to fix build

### DIFF
--- a/build.js
+++ b/build.js
@@ -5,7 +5,6 @@ const del = require('del');
 const chokidar = require('chokidar');
 const rollup = require('rollup');
 const sass = require('rollup-plugin-sass');
-const babel = require('rollup-plugin-babel');
 const resolve = require('rollup-plugin-node-resolve');
 const commonjs = require('rollup-plugin-commonjs');
 const promisify = require('util').promisify;
@@ -17,11 +16,6 @@ const argv = require('minimist')(process.argv.slice(2), {
 
 const rollupPlugins = [
   sass({options: {outputStyle: 'compressed'}}),
-  babel({
-    "plugins": [
-       ["transform-react-jsx"]
-     ]
-  }),
   resolve({ jsnext: true, main: true }),
   commonjs()
 ];

--- a/build.js
+++ b/build.js
@@ -17,6 +17,11 @@ const argv = require('minimist')(process.argv.slice(2), {
 
 const rollupPlugins = [
   sass({options: {outputStyle: 'compressed'}}),
+  babel({
+    "plugins": [
+       ["transform-react-jsx"]
+     ]
+  }),
   resolve({ jsnext: true, main: true }),
   commonjs()
 ];

--- a/doc-src/script.js
+++ b/doc-src/script.js
@@ -1,4 +1,4 @@
-/** @jsx h */
+import h from 'hyperhtml/esm';
 import Presentation from '../src/presentation';
 import Img from '../src/img';
 import {fadeBlank} from '../src/presentation/transitions';
@@ -33,14 +33,14 @@ presentation.slide('This is my first slide', async slide => {
 
   //const world = <div style="opacity: 0">World!</div>;
 
-  slide.append(
+  slide.append(h`
     <div fade-in>
       world
       <preso-img src="imgs/1.png" class="img-1"/>
       <preso-img src="imgs/2.png" class="img-2"/>
       <preso-img src="imgs/3.png" class="img-3"/>
     </div>
-  );
+  `);
 });
 
 presentation.transition(fadeBlank());

--- a/doc-src/script.js
+++ b/doc-src/script.js
@@ -2,7 +2,7 @@
 import Presentation from '../src/presentation';
 import Img from '../src/img';
 import {fadeBlank} from '../src/presentation/transitions';
-import {findTexts, h} from '../src/utils/dom';
+import {findTexts} from '../src/utils/dom';
 import {fadeIn} from '../src/utils/anims';
 const presentation = document.createElement('preso-presentation');
 document.body.append(presentation);


### PR DESCRIPTION
The current `master` does not build because rollup cannot process jsx in `doc-src`. There is also a non-existing import that was failing the build.

I gather from the recent comments that you are transitioning from jsx to hyperhtml. The sample presentation has been fixed to use hyperhtml so that the project builds.