### PR TITLE
Fix opening notes window

### DIFF
--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -82,7 +82,7 @@ export function* findTexts(str, {
 const localStorageKeyPrefix = 'are-you-there-';
 
 export function createDetectableWindow(name) {
-  const win = window.open(null, name,
+  const win = window.open('', name,
     'menubar=no,toolbar=no,location=no,status=no'
   );
 


### PR DESCRIPTION
Chrome gives `ERR_FILE_NOT_FOUND` when using `null` as the url of the new window.

Fixes #3 