### PR TITLE
Hide unnamed slides

### DIFF
--- a/src/presentation/notes/index.js
+++ b/src/presentation/notes/index.js
@@ -80,7 +80,11 @@ export default class Notes extends HTMLElement {
     const slideIndex = this._slideList.children.length;
     this._slideList.append(html`
       <li class="preso-slide-list__item">
-        <button data-slide-index=${slideIndex} class="preso-slide-list__button">${name}</button>
+        <button
+          data-slide-index=${slideIndex}
+          class="preso-slide-list__button"
+          hidden="${name === "Unknown slide"}"
+        >${name}</button>
       </li>
     `);
   }


### PR DESCRIPTION
I tried to do “the right thing” by preventing the unnamed slides to make it into the list in the first place, but slide selection is index-based, so it broke things.

This is a rather hacky approach, but does the thing. Your call :D